### PR TITLE
`SelectActor` button is now toggleable

### DIFF
--- a/VillageAssault/Content/Blueprints/BP_PlayerController.uasset
+++ b/VillageAssault/Content/Blueprints/BP_PlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2dc46297e9a637f33cf3717570a35ad3df09cf035fcc53bf97cb78da043098f3
-size 57539
+oid sha256:8f709cd66985f3a398b02695a1a376b6a01a4f73bafc9bd3ba7f99126b381209
+size 23463

--- a/VillageAssault/Content/Blueprints/MainMenu.uasset
+++ b/VillageAssault/Content/Blueprints/MainMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:beec6f6fb7959905900df37b9c34b49c283cc5271e13ba4df27972afe70e4ede
-size 47098
+oid sha256:f28d52cbbd0a8b51a57626102be641e5e85672c1ba2db7913d57d42367da5cca
+size 76427

--- a/VillageAssault/Content/SunnyLandAssets/environment/layers/props_Base.uasset
+++ b/VillageAssault/Content/SunnyLandAssets/environment/layers/props_Base.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15d6c0aeea77aa2756776dda0ac8b3246404e81e87c67c100317ec28b4be2d99
+oid sha256:0e38703615396a0f37ad4a733479ebc0e16e44701642ee8cd960a5b3bc7a5add
 size 18064


### PR DESCRIPTION
The `SelectActor` button is now toggleable between terrain and characters, and turns green when active. Solves #7