### PR TITLE
Fixed MovementPanel Widget Bug

### DIFF
--- a/VillageAssault/Content/Blueprints/UI_Elements/SelectTroop.uasset
+++ b/VillageAssault/Content/Blueprints/UI_Elements/SelectTroop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c869188be02d6757bf50d35e3dff018a9d5a86a50f411fc40bf898bde69b503
-size 86579
+oid sha256:80c75ede2d3637518ba1e16435c9d7aae18c689bf879d6a1a6066ec0627c186c
+size 99790


### PR DESCRIPTION
Fix #12. Clicking on a character more than once in the Troop Select screen no longer spawns multiple MovementPanel widgets, thanks to the implementation of a simple boolean check.